### PR TITLE
Fix Design System doc site navigation active element styling

### DIFF
--- a/www/src/components/sidenav.js
+++ b/www/src/components/sidenav.js
@@ -29,6 +29,20 @@ const StyledNavHeading = styled(Heading)({
   }
 })
 
+const activeStyle={
+  fontWeight: '700',
+  borderLeft: `4px solid ${COLORS.blue[500]}`,
+  background: COLORS.grey[200]
+}
+
+const isActive = ({
+  isPartiallyCurrent, href, location
+}) => {
+  return ( isPartiallyCurrent && location.pathname.match(href + '/?$') )
+    ? {style: activeStyle}
+    : {}
+}
+
 const StyledNavLink = styled(Link)({
   display: 'block',
   '&:hover': {
@@ -56,11 +70,7 @@ class NavSection extends React.Component {
             <li key={i}>
               <StyledNavLink
                 to={item.to}
-                activeStyle={{
-                  fontWeight: '700',
-                  borderLeft: `4px solid ${COLORS.blue[500]}`,
-                  background: COLORS.grey[200]
-                }}
+                getProps={isActive}
               >
                 {item.text}
               </StyledNavLink>


### PR DESCRIPTION
Use StyleLink.getProps to return the activeStyle if the current pathname matches the href with/out a trailing slash.

Closes LIBWEB-228