### PR TITLE
Add "main" entrypoint to each package.json file (PFDR-174)

### DIFF
--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/alert",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/button",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/chat",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/core",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@umich-lib/alert": "^1.0.0-alpha.7",

--- a/packages/expandable/package.json
+++ b/packages/expandable/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/expandable",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/header",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/heading/package.json
+++ b/packages/heading/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/heading",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/icon",
   "version": "1.0.0-alpha.8",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/input",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/link",
   "version": "0.1.1-alpha.0",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/list",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/loading/package.json
+++ b/packages/loading/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/loading",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/record-fields/package.json
+++ b/packages/record-fields/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/record-fields",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/resource-access/package.json
+++ b/packages/resource-access/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/resource-access",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/styles",
   "version": "2.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "files": [
     "lib"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/tabs",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/text-input",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/text",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",

--- a/packages/universal-header/package.json
+++ b/packages/universal-header/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@umich-lib/universal-header",
   "version": "1.0.0-alpha.7",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "dependencies": {
     "@emotion/core": "^10.0.7",


### PR DESCRIPTION
The "module" entrypoint appears to be sufficient for webpack/rollup, but
npm itself doesn't understand it, so, for example, if you want to run
tests with jest, it won't recognize any of these as modules that can be
imported from.

I've tested this by making this change under node_modules/ in a package
of mine, and this appeared to fix the problem.