### PR TITLE
Card on hover z-space is only for the image.

### DIFF
--- a/packages/card/src/index.js
+++ b/packages/card/src/index.js
@@ -22,13 +22,13 @@ export default function Card({
     display: 'block',
     maxWidth: '600px',
     ':hover': {
-      ...Z_SPACE[8],
+      '[data-card-image]': {
+        ...Z_SPACE[8],
+      },
       '.card--title': {
         ...LINK_STYLES['description'][':hover']
       }
-    },
-    borderRadius: '2px',
-    padding: SPACING['M']
+    }
   }
 
   const anchorProps = {
@@ -66,6 +66,7 @@ export default function Card({
       {image && (
         <div
           aria-hidden="true"
+          data-card-image
           css={{
             backgroundColor: COLORS.blue['100'],
             backgroundImage: `url(${image})`,


### PR DESCRIPTION
I read the design specs incorrectly. The on hover z-space is not for the entire card, but only for the image. This PR is that change after discussing with @elleande.

Preview: https://umich-lib-design-system-dmhmwau45.now.sh/components/card/code